### PR TITLE
Add MongoDB login and signup

### DIFF
--- a/ShopShap/README.md
+++ b/ShopShap/README.md
@@ -36,3 +36,6 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Configuration
+Set MONGO_URI in your environment to connect to MongoDB.

--- a/ShopShap/package.json
+++ b/ShopShap/package.json
@@ -20,9 +20,11 @@
 		"typescript": "^5.0.0",
 		"vite": "^6.2.6"
 	},
-	"dependencies": {
-		"@tailwindcss/vite": "^4.1.8",
-		"axios": "^1.9.0",
-		"tailwindcss": "^4.1.8"
-	}
+        "dependencies": {
+                "@tailwindcss/vite": "^4.1.8",
+                "axios": "^1.9.0",
+                "tailwindcss": "^4.1.8",
+                "bcryptjs": "^2.4.3",
+                "mongoose": "^8.3.1"
+        }
 }

--- a/ShopShap/src/lib/db.ts
+++ b/ShopShap/src/lib/db.ts
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const MONGO_URI = process.env.MONGO_URI || '';
+
+export async function connectDB() {
+  if (mongoose.connection.readyState >= 1) return;
+  await mongoose.connect(MONGO_URI);
+}
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, unique: true, required: true },
+  password: { type: String, required: true }
+});
+
+export const User = mongoose.models.User || mongoose.model('User', userSchema);

--- a/ShopShap/src/routes/login/+page.server.ts
+++ b/ShopShap/src/routes/login/+page.server.ts
@@ -1,0 +1,24 @@
+import { fail, redirect, type Actions } from '@sveltejs/kit';
+import bcrypt from 'bcryptjs';
+import { connectDB, User } from '$lib/db';
+
+export const actions: Actions = {
+  default: async ({ request, cookies }) => {
+    const data = await request.formData();
+    const email = String(data.get('email'));
+    const password = String(data.get('password'));
+
+    await connectDB();
+    const user = await User.findOne({ email });
+    if (!user || !(await bcrypt.compare(password, user.password))) {
+      return fail(400, { error: 'Invalid email or password' });
+    }
+
+    cookies.set('userId', user._id.toString(), {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'strict'
+    });
+    throw redirect(302, '/');
+  }
+};

--- a/ShopShap/src/routes/signup/+page.server.ts
+++ b/ShopShap/src/routes/signup/+page.server.ts
@@ -1,0 +1,30 @@
+import { fail, redirect, type Actions } from '@sveltejs/kit';
+import bcrypt from 'bcryptjs';
+import { connectDB, User } from '$lib/db';
+
+export const actions: Actions = {
+  default: async ({ request, cookies }) => {
+    const data = await request.formData();
+    const email = String(data.get('email'));
+    const password = String(data.get('password'));
+
+    if (!email || !password) {
+      return fail(400, { error: 'Missing email or password' });
+    }
+
+    await connectDB();
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return fail(400, { error: 'Email already exists' });
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ email, password: hashed });
+    cookies.set('userId', user._id.toString(), {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'strict'
+    });
+    throw redirect(302, '/');
+  }
+};

--- a/ShopShap/src/routes/signup/+page.svelte
+++ b/ShopShap/src/routes/signup/+page.svelte
@@ -4,7 +4,7 @@
 
 <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-pink-100 via-purple-100 to-indigo-100 py-12 px-4">
   <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8">
-    <h2 class="text-3xl font-bold text-center mb-6 text-indigo-700">Log In</h2>
+    <h2 class="text-3xl font-bold text-center mb-6 text-indigo-700">Sign Up</h2>
     <form method="POST" class="space-y-5">
       <div>
         <label class="block text-gray-700 mb-1 font-semibold">Email</label>
@@ -17,10 +17,10 @@
       {#if form?.error}
         <p class="text-red-500">{form.error}</p>
       {/if}
-      <button type="submit" class="w-full py-3 bg-pink-500 text-white font-bold rounded-lg shadow hover:bg-pink-600 transition">Log In</button>
+      <button type="submit" class="w-full py-3 bg-pink-500 text-white font-bold rounded-lg shadow hover:bg-pink-600 transition">Sign Up</button>
     </form>
     <div class="mt-6 text-center">
-      <a href="/signup" class="text-indigo-600 hover:underline font-semibold">Don't have an account? Sign Up</a>
+      <a href="/login" class="text-indigo-600 hover:underline font-semibold">Already have an account? Log In</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add mongoose and bcryptjs dependencies
- document MongoDB configuration
- create MongoDB connection and user model
- add login and signup server actions with cookie auth
- create signup page and update login page

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465da0f66c8321ba0b08a384f6e1d1