### PR TITLE
Add basic MongoDB auth

### DIFF
--- a/ShopShap/README.md
+++ b/ShopShap/README.md
@@ -36,3 +36,11 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Environment variables
+
+Set the `MONGODB_URI` variable to your MongoDB connection string before running the development server:
+
+```bash
+export MONGODB_URI="mongodb://localhost:27017/"
+```

--- a/ShopShap/package.json
+++ b/ShopShap/package.json
@@ -20,9 +20,11 @@
 		"typescript": "^5.0.0",
 		"vite": "^6.2.6"
 	},
-	"dependencies": {
-		"@tailwindcss/vite": "^4.1.8",
-		"axios": "^1.9.0",
-		"tailwindcss": "^4.1.8"
-	}
+        "dependencies": {
+                "@tailwindcss/vite": "^4.1.8",
+                "axios": "^1.9.0",
+                "tailwindcss": "^4.1.8",
+                "mongoose": "^8.0.1",
+                "bcryptjs": "^2.4.3"
+        }
 }

--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -28,9 +28,10 @@
                     </svg>
                 </button>
             </div>
-            <!-- Login/Sign Out buttons -->
+            <!-- Auth buttons -->
             <div class="hidden md:flex items-center gap-4 ml-6">
                 <a href="/login" class="px-4 py-2 rounded bg-sky-500 text-white font-semibold hover:bg-sky-600 transition">Log In</a>
+                <a href="/signup" class="px-4 py-2 rounded bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition">Sign Up</a>
                 <a href="/logout" class="px-4 py-2 rounded bg-gray-700 text-white font-semibold hover:bg-gray-600 transition">Sign Out</a>
             </div>
         </div>
@@ -41,6 +42,7 @@
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
             <a href="/login" class="block text-sky-500 bg-white font-semibold rounded px-3 py-2 mt-2">Log In</a>
+            <a href="/signup" class="block text-emerald-500 bg-white font-semibold rounded px-3 py-2 mt-1">Sign Up</a>
             <a href="/logout" class="block text-white bg-gray-700 font-semibold rounded px-3 py-2 mt-1">Sign Out</a>
         </div>
     {/if}

--- a/ShopShap/src/lib/server/db.ts
+++ b/ShopShap/src/lib/server/db.ts
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+let connection: typeof mongoose | null = null;
+
+export async function connectDB() {
+  if (connection) return connection;
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/';
+  connection = await mongoose.connect(uri);
+  return connection;
+}

--- a/ShopShap/src/lib/server/models/user.ts
+++ b/ShopShap/src/lib/server/models/user.ts
@@ -1,0 +1,8 @@
+import { Schema, model, models } from 'mongoose';
+
+const UserSchema = new Schema({
+  email: { type: String, unique: true, required: true },
+  password: { type: String, required: true }
+});
+
+export const User = models.User || model('User', UserSchema);

--- a/ShopShap/src/routes/login/+page.server.ts
+++ b/ShopShap/src/routes/login/+page.server.ts
@@ -1,0 +1,26 @@
+import { fail, redirect } from '@sveltejs/kit';
+import bcrypt from 'bcryptjs';
+import { connectDB } from '$lib/server/db';
+import { User } from '$lib/server/models/user';
+
+export const actions = {
+  default: async ({ request, cookies }) => {
+    const data = await request.formData();
+    const email = data.get('email');
+    const password = data.get('password');
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return fail(400, { message: 'Invalid form data' });
+    }
+    await connectDB();
+    const user = await User.findOne({ email });
+    if (!user) {
+      return fail(400, { message: 'Invalid credentials' });
+    }
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return fail(400, { message: 'Invalid credentials' });
+    }
+    cookies.set('user', String(user._id), { path: '/' });
+    throw redirect(303, '/');
+  }
+};

--- a/ShopShap/src/routes/login/+page.svelte
+++ b/ShopShap/src/routes/login/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let form: any;
+</script>
+
+<form method="POST" class="max-w-md mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-bold">Log In</h1>
+  {#if form?.message}
+    <p class="text-red-500">{form.message}</p>
+  {/if}
+  <div>
+    <label>Email</label>
+    <input type="email" name="email" class="border p-2 w-full" required />
+  </div>
+  <div>
+    <label>Password</label>
+    <input type="password" name="password" class="border p-2 w-full" required />
+  </div>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Log In</button>
+</form>

--- a/ShopShap/src/routes/logout/+server.ts
+++ b/ShopShap/src/routes/logout/+server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+
+export function GET({ cookies }) {
+  cookies.delete('user', { path: '/' });
+  throw redirect(303, '/');
+}

--- a/ShopShap/src/routes/signup/+page.server.ts
+++ b/ShopShap/src/routes/signup/+page.server.ts
@@ -1,0 +1,24 @@
+import { fail, redirect } from '@sveltejs/kit';
+import bcrypt from 'bcryptjs';
+import { connectDB } from '$lib/server/db';
+import { User } from '$lib/server/models/user';
+
+export const actions = {
+  default: async ({ request, cookies }) => {
+    const data = await request.formData();
+    const email = data.get('email');
+    const password = data.get('password');
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return fail(400, { message: 'Invalid form data' });
+    }
+    await connectDB();
+    const hashed = await bcrypt.hash(password, 10);
+    try {
+      const user = await User.create({ email, password: hashed });
+      cookies.set('user', String(user._id), { path: '/' });
+      throw redirect(303, '/');
+    } catch (err) {
+      return fail(400, { message: 'User already exists' });
+    }
+  }
+};

--- a/ShopShap/src/routes/signup/+page.svelte
+++ b/ShopShap/src/routes/signup/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let form: any;
+</script>
+
+<form method="POST" class="max-w-md mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-bold">Sign Up</h1>
+  {#if form?.message}
+    <p class="text-red-500">{form.message}</p>
+  {/if}
+  <div>
+    <label>Email</label>
+    <input type="email" name="email" class="border p-2 w-full" required />
+  </div>
+  <div>
+    <label>Password</label>
+    <input type="password" name="password" class="border p-2 w-full" required />
+  </div>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Sign Up</button>
+</form>


### PR DESCRIPTION
## Summary
- create MongoDB connector and user model
- implement signup and login forms with hashed passwords and cookie session
- add logout route and navigation links
- document `MONGODB_URI` environment variable

## Testing
- `npm install` *(fails: 403 Forbidden for bcryptjs)*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467fa0476c832194a0ba0a5f40d6f9