### PR TITLE
Add login-aware nav links

### DIFF
--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="ts">
+    export let user: string | null = null;
     let navOpen = false;
 </script>
 
@@ -30,9 +31,12 @@
             </div>
             <!-- Auth buttons -->
             <div class="hidden md:flex items-center gap-4 ml-6">
-                <a href="/login" class="px-4 py-2 rounded bg-sky-500 text-white font-semibold hover:bg-sky-600 transition">Log In</a>
-                <a href="/signup" class="px-4 py-2 rounded bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition">Sign Up</a>
-                <a href="/logout" class="px-4 py-2 rounded bg-gray-700 text-white font-semibold hover:bg-gray-600 transition">Sign Out</a>
+                {#if user}
+                    <a href="/logout" class="px-4 py-2 rounded bg-gray-700 text-white font-semibold hover:bg-gray-600 transition">Sign Out</a>
+                {:else}
+                    <a href="/login" class="px-4 py-2 rounded bg-sky-500 text-white font-semibold hover:bg-sky-600 transition">Log In</a>
+                    <a href="/signup" class="px-4 py-2 rounded bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition">Sign Up</a>
+                {/if}
             </div>
         </div>
     </div>
@@ -41,9 +45,12 @@
             <a href="/" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Home</a>
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
-            <a href="/login" class="block text-sky-500 bg-white font-semibold rounded px-3 py-2 mt-2">Log In</a>
-            <a href="/signup" class="block text-emerald-500 bg-white font-semibold rounded px-3 py-2 mt-1">Sign Up</a>
-            <a href="/logout" class="block text-white bg-gray-700 font-semibold rounded px-3 py-2 mt-1">Sign Out</a>
+            {#if user}
+                <a href="/logout" class="block text-white bg-gray-700 font-semibold rounded px-3 py-2 mt-1">Sign Out</a>
+            {:else}
+                <a href="/login" class="block text-sky-500 bg-white font-semibold rounded px-3 py-2 mt-2">Log In</a>
+                <a href="/signup" class="block text-emerald-500 bg-white font-semibold rounded px-3 py-2 mt-1">Sign Up</a>
+            {/if}
         </div>
     {/if}
 </nav>

--- a/ShopShap/src/routes/+layout.server.ts
+++ b/ShopShap/src/routes/+layout.server.ts
@@ -1,0 +1,5 @@
+export const load = async ({ cookies }) => {
+    const user = cookies.get('user');
+    return { user: user ?? null };
+};
+

--- a/ShopShap/src/routes/+layout.svelte
+++ b/ShopShap/src/routes/+layout.svelte
@@ -4,9 +4,10 @@
   import Nav from "../components/Nav.svelte";
   import Header from "../components/Nav.svelte";
   import Footer from "../components/Footer.svelte";
+  export let data: { user: string | null };
 </script>
 
-<Nav />
+<Nav user={data.user} />
   <slot />
 
   <Footer />


### PR DESCRIPTION
## Summary
- update navigation to hide login/signup when logged in
- show sign out link only when a user cookie exists
- load user cookie in new layout server load
- pass user data to nav via layout

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848499f3a30832197258f41ceca75fb