### PR TITLE
Add Google OAuth callback flow

### DIFF
--- a/ShopShap/src/routes/Oauth/callback/+server.ts
+++ b/ShopShap/src/routes/Oauth/callback/+server.ts
@@ -1,0 +1,42 @@
+import { redirect } from '@sveltejs/kit';
+import { OAuth2Client } from 'google-auth-library';
+import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, REDIRECT_URI, JWT_SECRET } from '$env/static/private';
+import { connectDB } from '$lib/server/db';
+import { User } from '$lib/server/models/user';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+const client = new OAuth2Client(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, REDIRECT_URI);
+
+export const GET = async ({ url, cookies }) => {
+  const code = url.searchParams.get('code');
+  if (!code) {
+    throw redirect(303, '/signup');
+  }
+
+  const { tokens } = await client.getToken(code);
+  const ticket = await client.verifyIdToken({
+    idToken: tokens.id_token ?? '',
+    audience: GOOGLE_CLIENT_ID
+  });
+
+  const payload = ticket.getPayload();
+  const email = payload?.email;
+  const name = payload?.name;
+  if (!email || !name) {
+    throw redirect(303, '/signup');
+  }
+
+  await connectDB();
+  let user = await User.findOne({ email });
+  if (!user) {
+    const randomPass = Math.random().toString(36).slice(-8);
+    const hashed = await bcrypt.hash(randomPass, 10);
+    user = await User.create({ email, name, password: hashed });
+  }
+
+  const token = jwt.sign({ userId: user._id }, JWT_SECRET, { expiresIn: '1h' });
+  cookies.set('token', token, { path: '/', httpOnly: true, maxAge: 3600 });
+
+  throw redirect(303, '/');
+};

--- a/ShopShap/src/routes/signup/+page.server.ts
+++ b/ShopShap/src/routes/signup/+page.server.ts
@@ -4,10 +4,6 @@ import { connectDB } from '$lib/server/db';
 import { User } from '$lib/server/models/user';
 import { JWT_SECRET } from '$env/static/private';
 import jwt from 'jsonwebtoken';
-import { OAuth2Client } from 'google-auth-library';
-import { GOOGLE_CLIENT_ID ,GOOGLE_CLIENT_SECRET } from '$env/static/private';
-
-const client = new OAuth2Client
 
 export const actions = {
   default: async ({ request, cookies }) => {

--- a/ShopShap/src/routes/signup/+page.svelte
+++ b/ShopShap/src/routes/signup/+page.svelte
@@ -23,3 +23,5 @@
   
   <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Sign Up</button>
 </form>
+
+<a href="/Oauth" class="block bg-red-500 text-white px-4 py-2 rounded mt-4 text-center">Sign up with Google</a>


### PR DESCRIPTION
## Summary
- handle OAuth callback to create/login users
- remove unused OAuth client from signup server
- add "Sign up with Google" button

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aeea545948321b935de44d4945935