### PR TITLE
Add simple cart support

### DIFF
--- a/ShopShap/src/components/Card.svelte
+++ b/ShopShap/src/components/Card.svelte
@@ -1,9 +1,22 @@
 <script lang="ts">
+    import { cart } from '$lib/stores/cart';
+
     export let id: number;
     export let title: string = '';
     export let description: string = '';
     export let price: string | number = '';
     export let images: string = '';
+
+    async function addToCart(event: Event) {
+        event.stopPropagation();
+        const item = { id, title, price: Number(price), images, quantity: 1 };
+        cart.add(item);
+        await fetch('/api/cart', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(item)
+        });
+    }
 </script>
 
 <div class="max-w-sm rounded overflow-hidden shadow-lg m-4 cursor-pointer" on:click={() => window.location.href = `/products/${id}`} tabindex="0" role="button">
@@ -16,8 +29,8 @@
         <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">${price}</span>
     </div>
     <div class="px-6 pt-4 pb-2">
-        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            View more
+        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" on:click={addToCart}>
+            Add to Cart
         </button>
     </div>
 </div>

--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -13,6 +13,7 @@
                     <div class="flex space-x-4 justify-center">
                         <a href="/" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Home</a>
                         <a href="/products" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Products</a>
+                        <a href="/checkout" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Cart</a>
                         <a href="/about" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">About</a>
                     </div>
                 </div>
@@ -45,6 +46,7 @@
         <div class="md:hidden px-2 pt-2 pb-3 space-y-1">
             <a href="/" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Home</a>
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
+            <a href="/checkout" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Cart</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
             {#if user}
                 <span class="block text-gray-300 px-3">{user.name}</span>

--- a/ShopShap/src/lib/server/cartStore.ts
+++ b/ShopShap/src/lib/server/cartStore.ts
@@ -1,0 +1,28 @@
+export type CartItem = {
+    id: number;
+    title: string;
+    price: number;
+    images: string;
+    quantity: number;
+};
+
+const carts = new Map<string, CartItem[]>();
+
+export function getCart(userId: string): CartItem[] {
+    return carts.get(userId) ?? [];
+}
+
+export function addItem(userId: string, item: CartItem) {
+    const cart = carts.get(userId) ?? [];
+    const existing = cart.find((i) => i.id === item.id);
+    if (existing) {
+        existing.quantity += item.quantity;
+    } else {
+        cart.push(item);
+    }
+    carts.set(userId, cart);
+}
+
+export function clearCart(userId: string) {
+    carts.set(userId, []);
+}

--- a/ShopShap/src/lib/stores/cart.ts
+++ b/ShopShap/src/lib/stores/cart.ts
@@ -1,0 +1,34 @@
+import { writable, derived } from 'svelte/store';
+
+export type CartItem = {
+    id: number;
+    title: string;
+    price: number;
+    images: string;
+    quantity: number;
+};
+
+function createCart() {
+    const { subscribe, set, update } = writable<CartItem[]>([]);
+    return {
+        subscribe,
+        add(item: Omit<CartItem, 'quantity'> & { quantity?: number }) {
+            update((items) => {
+                const qty = item.quantity ?? 1;
+                const existing = items.find((i) => i.id === item.id);
+                if (existing) {
+                    existing.quantity += qty;
+                    return [...items];
+                }
+                return [...items, { ...item, quantity: qty }];
+            });
+        },
+        set,
+        clear() { set([]); }
+    };
+}
+
+export const cart = createCart();
+export const cartTotal = derived(cart, ($cart) =>
+    $cart.reduce((sum, item) => sum + item.price * item.quantity, 0)
+);

--- a/ShopShap/src/routes/api/cart/+server.ts
+++ b/ShopShap/src/routes/api/cart/+server.ts
@@ -1,0 +1,23 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getCart, addItem, type CartItem } from '$lib/server/cartStore';
+
+export const GET: RequestHandler = ({ locals }) => {
+    const user = locals.user;
+    if (!user) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+    const cart = getCart(user.id);
+    return json(cart);
+};
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+    const user = locals.user;
+    if (!user) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+    const item: CartItem = await request.json();
+    addItem(user.id, { ...item, quantity: item.quantity ?? 1 });
+    const cart = getCart(user.id);
+    return json(cart);
+};

--- a/ShopShap/src/routes/checkout/+page.server.ts
+++ b/ShopShap/src/routes/checkout/+page.server.ts
@@ -1,0 +1,12 @@
+import type { PageServerLoad } from './$types';
+import { getCart } from '$lib/server/cartStore';
+import { redirect } from '@sveltejs/kit';
+
+export const load: PageServerLoad = ({ locals }) => {
+    const user = locals.user;
+    if (!user) {
+        throw redirect(303, '/login');
+    }
+    const cart = getCart(user.id);
+    return { cart };
+};

--- a/ShopShap/src/routes/checkout/+page.svelte
+++ b/ShopShap/src/routes/checkout/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { CartItem } from '$lib/stores/cart';
+  export let data: { cart: CartItem[] };
+
+  const items = data.cart;
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+</script>
+
+<section class="min-h-screen p-4">
+  <h1 class="text-3xl font-bold mb-4">Checkout</h1>
+  {#if items.length === 0}
+    <p>Your cart is empty.</p>
+  {:else}
+    <table class="min-w-full border mb-4">
+      <thead>
+        <tr class="bg-gray-100 text-left">
+          <th class="p-2">Product</th>
+          <th class="p-2">Quantity</th>
+          <th class="p-2">Price</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each items as item}
+          <tr class="border-t">
+            <td class="p-2">{item.title}</td>
+            <td class="p-2">{item.quantity}</td>
+            <td class="p-2">${item.price}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <p class="text-xl font-semibold">Total: ${total}</p>
+  {/if}
+</section>

--- a/ShopShap/src/routes/products/[id]/+page.svelte
+++ b/ShopShap/src/routes/products/[id]/+page.svelte
@@ -9,7 +9,19 @@
     };
   };
 
+  import { cart } from '$lib/stores/cart';
+
   const product = data.product;
+
+  async function addToCart() {
+    const item = { id: product.id, title: product.title, price: product.price, images: product.images, quantity: 1 };
+    cart.add(item);
+    await fetch('/api/cart', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(item)
+    });
+  }
 
   function back() {
     window.location.href = '/products';
@@ -29,8 +41,8 @@
         <button class="bg-blue-600 hover:bg-blue-700 text-white font-bold px-4 py-2 rounded" on:click={back}>
           Back to Products
         </button>
-        <button class="bg-emerald-500 hover:bg-emerald-600 text-white font-bold px-4 py-2 rounded">
-          Buy Now
+        <button class="bg-emerald-500 hover:bg-emerald-600 text-white font-bold px-4 py-2 rounded" on:click={addToCart}>
+          Add to Cart
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create in-memory cart store and API endpoints
- add Svelte store for cart handling
- update Card and product detail pages with Add to Cart actions
- show Cart link in navigation
- implement checkout page with total price

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf45aedec83219ec83f68ca2ad0d1