### PR TITLE
Add user cart and checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This mini-project is a personal playground for practicing full‑stack developme
 - **MongoDB** with Mongoose for data storage
 - User authentication with JWT tokens and Google OAuth
 - Fetches product data from [DummyJSON](https://dummyjson.com/)
+- Shopping cart with per-user checkout page
 
 ## Getting Started
 

--- a/ShopShap/src/components/Card.svelte
+++ b/ShopShap/src/components/Card.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
-    export let id: number;
-    export let title: string = '';
-    export let description: string = '';
-    export let price: string | number = '';
-    export let images: string = '';
+  export let id: number;
+  export let title: string = '';
+  export let description: string = '';
+  export let price: string | number = '';
+  export let images: string = '';
+  let added = false;
+  async function addToCart(event: MouseEvent) {
+    event.stopPropagation();
+    const res = await fetch('/cart', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ productId: id, title, price })
+    });
+    if (res.ok) {
+      added = true;
+    }
+  }
 </script>
 
 <div class="max-w-sm rounded overflow-hidden shadow-lg m-4 cursor-pointer" on:click={() => window.location.href = `/products/${id}`} tabindex="0" role="button">
@@ -16,9 +28,12 @@
         <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">${price}</span>
     </div>
     <div class="px-6 pt-4 pb-2">
-        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            View more
+        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" on:click|stopPropagation={addToCart}>
+            {#if added}
+                Added
+            {:else}
+                Add to Cart
+            {/if}
         </button>
     </div>
 </div>
-

--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -14,6 +14,7 @@
                         <a href="/" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Home</a>
                         <a href="/products" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Products</a>
                         <a href="/about" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">About</a>
+                        <a href="/checkout" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Checkout</a>
                     </div>
                 </div>
             </div>
@@ -46,6 +47,7 @@
             <a href="/" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Home</a>
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
+            <a href="/checkout" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Checkout</a>
             {#if user}
                 <span class="block text-gray-300 px-3">{user.name}</span>
                 <a href="/logout" class="block text-white bg-gray-700 font-semibold rounded px-3 py-2 mt-1">Sign Out</a>

--- a/ShopShap/src/lib/server/models/cart.ts
+++ b/ShopShap/src/lib/server/models/cart.ts
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const CartItemSchema = new mongoose.Schema({
+    productId: { type: Number, required: true },
+    title: String,
+    price: Number,
+    quantity: { type: Number, default: 1 }
+});
+
+const CartSchema = new mongoose.Schema({
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
+    items: [CartItemSchema]
+});
+
+export const Cart = mongoose.models.Cart || mongoose.model('Cart', CartSchema);

--- a/ShopShap/src/routes/cart/+server.ts
+++ b/ShopShap/src/routes/cart/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import { Cart } from '$lib/server/models/cart';
+import { connectDB } from '$lib/server/db';
+
+export async function GET({ locals }) {
+    if (!locals.user) {
+        return json([]);
+    }
+    await connectDB();
+    const cart = await Cart.findOne({ userId: locals.user.id });
+    return json(cart?.items || []);
+}
+
+export async function POST({ request, locals }) {
+    if (!locals.user) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+    const { productId, title, price } = await request.json();
+    await connectDB();
+    let cart = await Cart.findOne({ userId: locals.user.id });
+    if (!cart) {
+        cart = await Cart.create({ userId: locals.user.id, items: [] });
+    }
+    const existing = cart.items.find((i:any) => i.productId === productId);
+    if (existing) {
+        existing.quantity += 1;
+    } else {
+        cart.items.push({ productId, title, price, quantity: 1 });
+    }
+    await cart.save();
+    return json(cart.items);
+}

--- a/ShopShap/src/routes/checkout/+page.server.ts
+++ b/ShopShap/src/routes/checkout/+page.server.ts
@@ -1,0 +1,18 @@
+import { Cart } from '$lib/server/models/cart';
+import { connectDB } from '$lib/server/db';
+
+export const load = async ({ locals }) => {
+    if (!locals.user) {
+        return { items: [], total: 0 };
+    }
+    await connectDB();
+    const cart = await Cart.findOne({ userId: locals.user.id });
+    const items = cart?.items.map((i:any) => ({
+        productId: i.productId,
+        title: i.title,
+        price: i.price,
+        quantity: i.quantity
+    })) || [];
+    const total = items.reduce((sum:number, item:any) => sum + item.price * item.quantity, 0);
+    return { items, total };
+};

--- a/ShopShap/src/routes/checkout/+page.svelte
+++ b/ShopShap/src/routes/checkout/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  export let data: { items: any[]; total: number };
+</script>
+
+<section class="min-h-screen p-8">
+  <h1 class="text-3xl font-bold mb-6">Checkout</h1>
+  {#if data.items.length === 0}
+    <p>No items in cart.</p>
+  {:else}
+    <table class="min-w-full mb-4">
+      <thead>
+        <tr>
+          <th class="text-left">Product</th>
+          <th>Quantity</th>
+          <th>Price</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.items as item}
+          <tr>
+            <td>{item.title}</td>
+            <td class="text-center">{item.quantity}</td>
+            <td class="text-right">${item.price}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <p class="text-xl font-semibold">Total: ${data.total}</p>
+  {/if}
+</section>


### PR DESCRIPTION
## Summary
- enable shopping cart per user with a new Mongoose model
- add API routes to get/add cart items
- update product cards with "Add to Cart" button
- create checkout page to list cart items and show the total
- link the new checkout page in the navigation
- document the new feature in README

## Testing
- `npm run check` *(fails: svelte-kit not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cf45aedec83219ec83f68ca2ad0d1