### PR TITLE
Add basic cart feature

### DIFF
--- a/ShopShap/src/components/Card.svelte
+++ b/ShopShap/src/components/Card.svelte
@@ -4,6 +4,27 @@
     export let description: string = '';
     export let price: string | number = '';
     export let images: string = '';
+    export let userId: string | null = null;
+
+    import { cartStore } from '../lib/stores/cart';
+    import { onMount } from 'svelte';
+
+    let cart: ReturnType<typeof cartStore> | null = null;
+
+    onMount(() => {
+        if (userId) {
+            cart = cartStore(userId);
+        }
+    });
+
+    function addToCart(event: Event) {
+        event.stopPropagation();
+        if (!cart) {
+            window.location.href = '/login';
+            return;
+        }
+        cart.add({ id, title, price: Number(price) });
+    }
 </script>
 
 <div class="max-w-sm rounded overflow-hidden shadow-lg m-4 cursor-pointer" on:click={() => window.location.href = `/products/${id}`} tabindex="0" role="button">
@@ -16,8 +37,11 @@
         <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">${price}</span>
     </div>
     <div class="px-6 pt-4 pb-2">
-        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            View more
+        <button
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            on:click={addToCart}
+        >
+            Add to Cart
         </button>
     </div>
 </div>

--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -13,6 +13,7 @@
                     <div class="flex space-x-4 justify-center">
                         <a href="/" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Home</a>
                         <a href="/products" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Products</a>
+                        <a href="/checkout" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Checkout</a>
                         <a href="/about" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">About</a>
                     </div>
                 </div>
@@ -45,6 +46,7 @@
         <div class="md:hidden px-2 pt-2 pb-3 space-y-1">
             <a href="/" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Home</a>
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
+            <a href="/checkout" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Checkout</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
             {#if user}
                 <span class="block text-gray-300 px-3">{user.name}</span>

--- a/ShopShap/src/lib/stores/cart.ts
+++ b/ShopShap/src/lib/stores/cart.ts
@@ -1,0 +1,57 @@
+import { writable, get } from 'svelte/store';
+
+export interface CartItem {
+  id: number;
+  title: string;
+  price: number;
+  quantity: number;
+}
+
+const stores: Record<string, ReturnType<typeof writable<CartItem[]>>> = {};
+
+export function cartStore(userId: string) {
+  const key = `cart-${userId}`;
+  if (!stores[userId]) {
+    let initial: CartItem[] = [];
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem(key);
+      if (stored) {
+        try { initial = JSON.parse(stored); } catch {}
+      }
+    }
+    const store = writable<CartItem[]>(initial);
+    store.subscribe((items) => {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, JSON.stringify(items));
+      }
+    });
+    stores[userId] = store;
+  }
+
+  const store = stores[userId];
+
+  return {
+    subscribe: store.subscribe,
+    add(item: Omit<CartItem, 'quantity'>) {
+      store.update((items) => {
+        const existing = items.find((i) => i.id === item.id);
+        if (existing) {
+          existing.quantity += 1;
+        } else {
+          items.push({ ...item, quantity: 1 });
+        }
+        return [...items];
+      });
+    },
+    remove(id: number) {
+      store.update((items) => items.filter((i) => i.id !== id));
+    },
+    clear() {
+      store.set([]);
+    },
+    total() {
+      const items = get(store);
+      return items.reduce((t, i) => t + i.price * i.quantity, 0);
+    }
+  };
+}

--- a/ShopShap/src/routes/+page.svelte
+++ b/ShopShap/src/routes/+page.svelte
@@ -76,6 +76,7 @@ const testimonials = [
     description={description}
     price={price}
     images={images}
+    userId={data.user?.id}
   />
 {/each}
 </section>

--- a/ShopShap/src/routes/checkout/+page.svelte
+++ b/ShopShap/src/routes/checkout/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { cartStore } from '$lib/stores/cart';
+  import { onMount } from 'svelte';
+  export let data;
+
+  let items = [];
+  let total = 0;
+  let cart: ReturnType<typeof cartStore> | null = null;
+
+  onMount(() => {
+    if (data.user) {
+      cart = cartStore(data.user.id);
+      cart.subscribe((v) => {
+        items = v;
+        total = cart?.total() ?? 0;
+      });
+    }
+  });
+</script>
+
+{#if !data.user}
+  <p class="text-center mt-10">Please <a href="/login" class="text-blue-500 underline">log in</a> to view your cart.</p>
+{:else}
+  <section class="max-w-xl mx-auto p-6">
+    <h1 class="text-2xl font-bold mb-4">Checkout</h1>
+    {#if items.length === 0}
+      <p>Your cart is empty.</p>
+    {:else}
+      <ul class="divide-y divide-gray-300">
+        {#each items as item}
+          <li class="py-2 flex justify-between items-center">
+            <span>{item.title} x {item.quantity}</span>
+            <span>${item.price * item.quantity}</span>
+            <button class="text-red-500" on:click={() => cart?.remove(item.id)}>Remove</button>
+          </li>
+        {/each}
+      </ul>
+      <div class="text-right font-bold mt-4">Total: ${total}</div>
+    {/if}
+  </section>
+{/if}

--- a/ShopShap/src/routes/products/+page.svelte
+++ b/ShopShap/src/routes/products/+page.svelte
@@ -25,6 +25,7 @@
         description={description}
         price={price}
         images={images}
+        userId={data.user?.id}
       />
     {/each}
   </div>


### PR DESCRIPTION
## Summary
- create cart store for per-user carts in localStorage
- switch card button text to "Add to Cart" and hook up cart logic
- pass user id to Card components
- add Checkout page that lists items and shows total
- link Checkout in navigation

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf45aedec83219ec83f68ca2ad0d1