### PR TITLE
Implement basic client-side cart

### DIFF
--- a/ShopShap/src/components/Card.svelte
+++ b/ShopShap/src/components/Card.svelte
@@ -1,9 +1,23 @@
 <script lang="ts">
+    import { cart } from '$lib/stores/cart';
+    import { page } from '$app/stores';
+    import { get } from 'svelte/store';
+
     export let id: number;
     export let title: string = '';
     export let description: string = '';
     export let price: string | number = '';
     export let images: string = '';
+
+    function addToCart(event: Event) {
+        event.stopPropagation();
+        const userId = get(page).data.user?.id;
+        if (!userId) {
+            alert('Please log in to add items to your cart.');
+            return;
+        }
+        cart.addItem(userId, { id, title, price: Number(price), images });
+    }
 </script>
 
 <div class="max-w-sm rounded overflow-hidden shadow-lg m-4 cursor-pointer" on:click={() => window.location.href = `/products/${id}`} tabindex="0" role="button">
@@ -16,8 +30,8 @@
         <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">${price}</span>
     </div>
     <div class="px-6 pt-4 pb-2">
-        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            View more
+        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" on:click={addToCart}>
+            Add to Cart
         </button>
     </div>
 </div>

--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -13,6 +13,7 @@
                     <div class="flex space-x-4 justify-center">
                         <a href="/" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Home</a>
                         <a href="/products" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Products</a>
+                        <a href="/checkout" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">Cart</a>
                         <a href="/about" class="text-gray-300 hover:text-sky-300 transition-colors duration-[500ms] px-3 py-2 rounded-md text-sm font-medium">About</a>
                     </div>
                 </div>
@@ -45,6 +46,7 @@
         <div class="md:hidden px-2 pt-2 pb-3 space-y-1">
             <a href="/" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Home</a>
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
+            <a href="/checkout" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Cart</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
             {#if user}
                 <span class="block text-gray-300 px-3">{user.name}</span>

--- a/ShopShap/src/lib/stores/cart.ts
+++ b/ShopShap/src/lib/stores/cart.ts
@@ -1,0 +1,57 @@
+import { writable } from 'svelte/store';
+
+export interface CartItem {
+    id: number;
+    title: string;
+    price: number;
+    images: string;
+    quantity: number;
+}
+
+interface CartRecord {
+    [userId: string]: CartItem[];
+}
+
+function createCart() {
+    let initial: CartRecord = {};
+    if (typeof localStorage !== 'undefined') {
+        const stored = localStorage.getItem('cart');
+        if (stored) {
+            try { initial = JSON.parse(stored); } catch {}
+        }
+    }
+    const { subscribe, update, set } = writable<CartRecord>(initial);
+
+    function persist(value: CartRecord) {
+        if (typeof localStorage !== 'undefined') {
+            localStorage.setItem('cart', JSON.stringify(value));
+        }
+    }
+
+    return {
+        subscribe,
+        addItem(userId: string, item: Omit<CartItem, 'quantity'>) {
+            update(carts => {
+                const userCart = carts[userId] || [];
+                const existing = userCart.find(ci => ci.id === item.id);
+                if (existing) {
+                    existing.quantity += 1;
+                } else {
+                    userCart.push({ ...item, quantity: 1 });
+                }
+                carts[userId] = userCart;
+                persist(carts);
+                return carts;
+            });
+        },
+        clear(userId: string) {
+            update(carts => {
+                carts[userId] = [];
+                persist(carts);
+                return carts;
+            });
+        }
+    };
+}
+
+export const cart = createCart();

--- a/ShopShap/src/routes/checkout/+page.svelte
+++ b/ShopShap/src/routes/checkout/+page.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { cart } from '$lib/stores/cart';
+  import { page } from '$app/stores';
+  import { get } from 'svelte/store';
+
+  export let data;
+
+  const userId = get(page).data.user?.id;
+  let items = [] as any[];
+  let total = 0;
+
+  $: if (userId) {
+    const all = get(cart);
+    items = all[userId] ?? [];
+    total = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
+  }
+</script>
+
+<section class="min-h-screen p-8">
+  <h1 class="text-3xl font-bold mb-6">Checkout</h1>
+  {#if userId}
+    {#if items.length === 0}
+      <p>Your cart is empty.</p>
+    {:else}
+      <table class="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th class="py-2">Product</th>
+            <th class="py-2">Qty</th>
+            <th class="py-2">Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each items as item}
+            <tr>
+              <td class="border px-4 py-2">{item.title}</td>
+              <td class="border px-4 py-2 text-center">{item.quantity}</td>
+              <td class="border px-4 py-2">${item.price * item.quantity}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+      <p class="mt-4 text-xl font-semibold">Total: ${total}</p>
+    {/if}
+  {:else}
+    <p>Please log in to view your cart.</p>
+  {/if}
+</section>


### PR DESCRIPTION
## Summary
- add cart store for persisting user cart per ID
- switch product cards to use Add to Cart button
- provide a simple checkout page summarising cart totals
- expose Cart link in the navigation

## Testing
- `npm run check` *(fails: `svelte-kit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf45aedec83219ec83f68ca2ad0d1