### PR TITLE
Add simple cart functionality

### DIFF
--- a/ShopShap/src/components/Card.svelte
+++ b/ShopShap/src/components/Card.svelte
@@ -4,6 +4,10 @@
     export let description: string = '';
     export let price: string | number = '';
     export let images: string = '';
+    import { cart } from '../lib/stores/cart';
+    import { fly } from 'svelte/transition';
+
+    $: item = $cart.find(p => p.id === id);
 </script>
 
 <div class="max-w-sm rounded overflow-hidden shadow-lg m-4 cursor-pointer" on:click={() => window.location.href = `/products/${id}`} tabindex="0" role="button">
@@ -16,9 +20,20 @@
         <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">${price}</span>
     </div>
     <div class="px-6 pt-4 pb-2">
-        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            View more
-        </button>
+        {#if item}
+            <div class="flex items-center gap-2">
+                <button class="bg-gray-300 px-2 rounded" on:click|stopPropagation={() => {
+                    if(item.quantity === 1 && !confirm('Do you want to remove this item?')) return;
+                    cart.decrement(id);
+                }}>-</button>
+                <span>{item.quantity}</span>
+                <button class="bg-gray-300 px-2 rounded" on:click|stopPropagation={() => cart.increment(id)}>+</button>
+            </div>
+        {:else}
+            <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" on:click|stopPropagation={() => cart.add({ id, title, price: +price, images })} transition:fly={{y:5,duration:150}}>
+                Add to Cart
+            </button>
+        {/if}
     </div>
 </div>
 

--- a/ShopShap/src/components/Nav.svelte
+++ b/ShopShap/src/components/Nav.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     export let user: { name: string } | null = null;
     let navOpen = false;
+    import { totalCount } from '../lib/stores/cart';
 </script>
 
 <nav class="bg-gray-800">
@@ -30,8 +31,18 @@
                 </button>
             </div>
                 <div class="hidden md:flex items-center gap-4 ml-6">
+                    <a href="/checkout" class="relative text-gray-300 hover:text-white">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4" />
+                            <circle cx="7" cy="21" r="1" />
+                            <circle cx="20" cy="21" r="1" />
+                        </svg>
+                        {#if $totalCount > 0}
+                        <span class="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full px-1">{$totalCount}</span>
+                        {/if}
+                    </a>
                     {#if user}
-                        <img src="https://placehold.co/40x40" alt="User Avatar" class="rounded-full w-8 h-8 mr-2" />
+                        <img src="https://placehold.co/40x40" alt="User Avatar" class="rounded-full w-8 h-8" />
                         <span class="text-gray-300">{user.name.toUpperCase()}</span>
                         <a href="/logout" class="px-4 py-2 rounded bg-gray-700 text-white font-semibold hover:bg-gray-600 transition">Sign Out</a>
                     {:else}
@@ -46,6 +57,16 @@
             <a href="/" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Home</a>
             <a href="/products" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">Products</a>
             <a href="/about" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium">About</a>
+            <a href="/checkout" class="block text-gray-300 hover:text-sky-300 transition-colors duration-[2000ms] px-3 py-2 rounded-md text-base font-medium flex items-center gap-1">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4" />
+                    <circle cx="7" cy="21" r="1" />
+                    <circle cx="20" cy="21" r="1" />
+                </svg>
+                {#if $totalCount > 0}
+                <span class="text-xs bg-red-500 text-white rounded-full px-1">{$totalCount}</span>
+                {/if}
+            </a>
             {#if user}
                 <span class="block text-gray-300 px-3">{user.name}</span>
                 <a href="/logout" class="block text-white bg-gray-700 font-semibold rounded px-3 py-2 mt-1">Sign Out</a>

--- a/ShopShap/src/lib/stores/cart.ts
+++ b/ShopShap/src/lib/stores/cart.ts
@@ -1,0 +1,53 @@
+import { writable, derived } from 'svelte/store';
+
+export interface CartItem {
+  id: number;
+  title: string;
+  price: number;
+  images: string;
+  quantity: number;
+}
+
+function createCart() {
+  const { subscribe, update } = writable<CartItem[]>([]);
+
+  return {
+    subscribe,
+    add(item: Omit<CartItem, 'quantity'>) {
+      update(items => {
+        const existing = items.find(i => i.id === item.id);
+        if (existing) {
+          existing.quantity += 1;
+          return [...items];
+        }
+        return [...items, { ...item, quantity: 1 }];
+      });
+    },
+    remove(id: number) {
+      update(items => items.filter(i => i.id !== id));
+    },
+    increment(id: number) {
+      update(items => {
+        const item = items.find(i => i.id === id);
+        if (item) item.quantity += 1;
+        return [...items];
+      });
+    },
+    decrement(id: number) {
+      update(items => {
+        const item = items.find(i => i.id === id);
+        if (item) {
+          item.quantity -= 1;
+          if (item.quantity <= 0) {
+            return items.filter(i => i.id !== id);
+          }
+        }
+        return [...items];
+      });
+    }
+  };
+}
+
+export const cart = createCart();
+export const totalCount = derived(cart, $cart => $cart.reduce((a, b) => a + b.quantity, 0));
+export const totalPrice = derived(cart, $cart => $cart.reduce((a, b) => a + b.price * b.quantity, 0));

--- a/ShopShap/src/routes/checkout/+page.svelte
+++ b/ShopShap/src/routes/checkout/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { cart, totalPrice } from '../../lib/stores/cart';
+</script>
+
+<section class="min-h-screen p-8">
+  <h1 class="text-3xl font-bold mb-6">Checkout</h1>
+  {#if $cart.length === 0}
+    <p>Your cart is empty.</p>
+  {:else}
+    <table class="w-full mb-4">
+      <thead>
+        <tr class="text-left border-b">
+          <th class="py-2">Product</th>
+          <th class="py-2">Qty</th>
+          <th class="py-2">Price</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each $cart as item}
+          <tr class="border-b">
+            <td class="py-2">{item.title}</td>
+            <td class="py-2">
+              <button class="px-2" on:click={() => cart.decrement(item.id)}>-</button>
+              <span class="px-2">{item.quantity}</span>
+              <button class="px-2" on:click={() => cart.increment(item.id)}>+</button>
+            </td>
+            <td class="py-2">${item.price * item.quantity}</td>
+            <td class="py-2">
+              <button class="text-red-600" on:click={() => cart.remove(item.id)}>Remove</button>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <div class="text-right font-semibold">Total: ${$totalPrice}</div>
+  {/if}
+</section>


### PR DESCRIPTION
## Summary
- provide cart store with helpers
- show cart icon with item count in navigation
- replace `View more` button with add-to-cart controls
- add a minimal checkout page displaying cart contents

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfa52ee30832193e40d977131b137